### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/gwen-lg/subtile-ocr/compare/v0.2.1...v0.2.2) - 2025-01-07
+
+### Added
+
+- *(puffin)* use a BufWriter for pref stats file
+
+### Other
+
+- *(gitignore)* remove data files of ignore
+- *(release-plz)* configure Release-plz for pr
+- *(cargo)* fix alphabetical order of dependencies
+- *(cargo)* update subtile dependendies to 0.3.1
+- fix github workflows change for trigger code_check
+- *(cargo)* update dependendies
+
 ## [0.2.1](https://github.com/gwen-lg/subtile-ocr/compare/v0.2.0...v0.2.1) - 2024-08-11
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "subtile-ocr"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtile-ocr"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Eliza Velasquez", "Gwen Lg <me@gwenlg.fr>"]
 edition = "2021"
 description = "Converts DVD VOB subtitles to SRT subtitles with Tesseract OCR"


### PR DESCRIPTION
## 🤖 New release
* `subtile-ocr`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/gwen-lg/subtile-ocr/compare/v0.2.1...v0.2.2) - 2025-01-07

### Added

- *(puffin)* use a BufWriter for pref stats file

### Other

- *(gitignore)* remove data files of ignore
- *(release-plz)* configure Release-plz for pr
- *(cargo)* fix alphabetical order of dependencies
- *(cargo)* update subtile dependendies to 0.3.1
- fix github workflows change for trigger code_check
- *(cargo)* update dependendies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).