### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/gwen-lg/subtile-ocr/compare/v0.2.3...v0.2.4) - 2025-02-08
+
+### Added
+
+- *(ocr)* export ocr::process symbol
+
+### Fixed
+
+- *(ocr)* also init `TESSERACT` on main thread
+
+### Other
+
+- *(ocr)* error for already initialized TESSERACT
+- *(ocr)* manage Tesseract init error
+- *(code_check)* add `--locked` to cargo steps
+- *(code_check)* remove `exit 1` in error summary check
+- *(ocr)* Add documentation to ocr::Error
+
 ## [0.2.3](https://github.com/gwen-lg/subtile-ocr/compare/v0.2.2...v0.2.3) - 2025-01-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "subtile-ocr"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subtile-ocr"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Eliza Velasquez", "Gwen Lg <me@gwenlg.fr>"]
 edition = "2021"
 description = "Converts DVD VOB subtitles to SRT subtitles with Tesseract OCR"


### PR DESCRIPTION



## 🤖 New release

* `subtile-ocr`: 0.2.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.4](https://github.com/gwen-lg/subtile-ocr/compare/v0.2.3...v0.2.4) - 2025-02-08

### Added

- *(ocr)* export ocr::process symbol

### Fixed

- *(ocr)* also init `TESSERACT` on main thread

### Other

- *(ocr)* error for already initialized TESSERACT
- *(ocr)* manage Tesseract init error
- *(code_check)* add `--locked` to cargo steps
- *(code_check)* remove `exit 1` in error summary check
- *(ocr)* Add documentation to ocr::Error
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).