### PR TITLE
ci: ignore `wip*` branch on push

### DIFF
--- a/.github/workflows/code_check.yml
+++ b/.github/workflows/code_check.yml
@@ -3,6 +3,8 @@ run-name: Checks Rust code on ${{ github.event_name }}
 
 on:
   push:
+    branches-ignore:
+      - "wip*"
     paths:
       - ".github/workflows/code_check.yml"
       - "Cargo.*"


### PR DESCRIPTION
This avoid trigger ci check on wip work, who can trigger a lot of error.